### PR TITLE
should be able to resolve a service by label or display name fixes #2

### DIFF
--- a/cf.js
+++ b/cf.js
@@ -193,7 +193,8 @@ function buildServiceCache(cfServices, cache) {
 						description: service.entity.description,
 						label: service.entity.label,
 						display_name: displayName || service.entity.label,
-						doc_url: documentationUrl || null
+						doc_url: documentationUrl || null,
+						deprecated: Array.isArray(service.entity.tags) && service.entity.tags.indexOf('ibm_deprecated') > -1
 					});
 				});
 
@@ -216,7 +217,7 @@ function buildServiceCache(cfServices, cache) {
  */
 function getServiceGuid(serviceName) {
 	for (let i = 0; i < this.serviceCache.length; i++) {
-		if (this.serviceCache[i].label === serviceName) {
+		if (this.serviceCache[i].label === serviceName || this.serviceCache[i].display_name === serviceName) {
 			return this.serviceCache[i].guid;
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-cf-convenience",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Small collection of syntactic sugar convenience functions for cf-nodejs-client.`",
   "license": "Apache-2.0",
   "main": "cf.js",

--- a/test/cf.test.js
+++ b/test/cf.test.js
@@ -59,6 +59,15 @@ describe('Test CF Convenience', function() {
 			});
 		});
 
+		it('should get service by display name', function(done) {
+			let testDone = done;
+			cf.promise.then(() => {
+				let guid = cf.getServiceGuid('A ValidService2 Display Name');
+				expect(guid).to.be.a.string;
+				testDone();
+			});
+		});
+
 		it('should get the active space', function(done) {
 			let testDone = done;
 			cf.promise.then(() => {
@@ -81,6 +90,28 @@ describe('Test CF Convenience', function() {
 				testDone();
 			}).catch((err) => {
 				console.log(err);
+			});
+		});
+	});
+
+	context('Validate service data', function() {
+		it('should detect deprecated services', function(done) {
+			let testDone = done;
+			cf.promise.then((result) => {
+				let service1, service2;
+				result.serviceCache.forEach((service) => {
+					if(service.guid === 'validService1Guid') {
+						service1 = service;
+					}
+					else if(service.guid === 'validService2Guid') {
+						service2 = service;
+					}
+				});
+				expect(service1).to.be.a.object;
+				expect(service2).to.be.a.object;
+				expect(service1.deprecated).to.be.false;
+				expect(service2.deprecated).to.be.true;
+				testDone();
 			});
 		});
 	});

--- a/test/resources/apps/test.resources.js
+++ b/test/resources/apps/test.resources.js
@@ -257,7 +257,13 @@ module.exports = {
 				},
 				entity: {
 					label: 'validService2',
-					description: 'Description of validService2'
+					description: 'Description of validService2',
+					tags: [
+						'mobile',
+						'ibm_experimental',
+						'ibm_deprecated'
+					],
+					extra: '{\"displayName\":\"A ValidService2 Display Name\"}'
 				}
 			}
 		]


### PR DESCRIPTION
@clanzen There are actually 2 fixes here.  One is search by display name.  The other is ability to detect deprecated tag within service catalog and include this in the service cache.  I need this b/c the crawler config generation tool will check this flag and not include such services when configuring the crawler.
